### PR TITLE
Add skaffold config and instructions

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,0 +1,14 @@
+apiVersion: skaffold/v1alpha2
+kind: Config
+build:
+  artifacts:
+  - imageName: gcr.io/cicd-ftw/ccweb
+    workspace: ./web
+  - imageName: gcr.io/cicd-ftw/ccworker
+    workspace: ./worker
+  local: {}
+deploy:
+  kubectl:
+    manifests:
+    - web/k8config/*
+    - worker/k8config/*

--- a/web/k8config/deployment.yaml
+++ b/web/k8config/deployment.yaml
@@ -19,8 +19,7 @@ spec:
     spec:
       containers:
       - name: cloudcats-web
-        image: gcr.io/cicd-ftw/ccweb:latest
-        imagePullPolicy: Always
+        image: gcr.io/cicd-ftw/ccweb
         ports:
         - name: http-server
           containerPort: 8080

--- a/worker/k8config/deployment.yaml
+++ b/worker/k8config/deployment.yaml
@@ -19,8 +19,7 @@ spec:
     spec:
       containers:
       - name: cloudcats-worker
-        image: gcr.io/cicd-ftw/ccworker:latest
-        imagePullPolicy: Always
+        image: gcr.io/cicd-ftw/ccworker
         ports:
         - name: http-server
           containerPort: 8081


### PR DESCRIPTION
This adds a skaffold.yaml to the repo so that you can run a skaffold
dev/run. I was able to get the example working pretty quickly! (Dogs won, as they should)

Here's some quick instructions that I would be happy to convert to readme form:

0. install minikube, install skaffold, start minikube

1. copy the keyfile.json to web and worker subdirectories
2. run `skaffold dev` from the root directory
3. once you start seeing logs indicating the services are up, run `minikube service cloudcats-web` to see the web UI

(optional 4) make some changes, and see the web and backend get rebuilt and redeployed!

This also makes all of the update scripts obsolete, which I'm happy to remove in a different PR.

This will also work with a GKE cluster, as long as you change the image names to a GCR project you are authenticated to.

cc @kimsterv
